### PR TITLE
Fix: payload not passed correctly in POST /dataset request

### DIFF
--- a/src/app/ingestor/ingestor/helper/ingestor-api-manager.ts
+++ b/src/app/ingestor/ingestor/helper/ingestor-api-manager.ts
@@ -136,10 +136,12 @@ export class IngestorAPIManager {
   public startIngestion(payload: PostDatasetRequest): Promise<string> {
     return new Promise((resolve, reject) => {
       this.http
-        .post(this.connectUrl + INGESTOR_API_ENDPOINTS_V1.DATASET, {
+        .post(this.connectUrl + INGESTOR_API_ENDPOINTS_V1.DATASET, 
           payload,
+          {
           ...this.connectOptions,
-        })
+          }
+        )
         .subscribe(
           (response) => {
             const returnValue = JSON.stringify(response);


### PR DESCRIPTION
Fixes
`error in openapi3filter.RequestError: request body has an error: doesn't match schema #/components/schemas/PostDatasetRequest: Error at "/metaData": property "metaData" is missing`

when trying to ingest a dataset. 
Not sure if it is entirely correct.

@dwiessner-unibe 