### PR TITLE
Add scicat token to jobparams

### DIFF
--- a/src/app/datasets/archiving.service.ts
+++ b/src/app/datasets/archiving.service.ts
@@ -7,6 +7,7 @@ import {
   selectCurrentUser,
   selectTapeCopies,
   selectProfile,
+  selectScicatToken,
 } from "state-management/selectors/user.selectors";
 import { RetrieveDestinations } from "app-config.service";
 import {
@@ -17,20 +18,24 @@ import {
 @Injectable()
 export class ArchivingService {
   private currentUser$ = this.store.select(selectCurrentUser);
+  private scicatToken$ = this.store.select(selectScicatToken);
   private tapeCopies$ = this.store.select(selectTapeCopies);
 
   constructor(private store: Store) {}
 
   private createJob(
     user: ReturnedUserDto,
+    scicatToken: string,
     datasets: OutputDatasetObsoleteDto[],
     archive: boolean,
     destinationPath?: Record<string, string>,
     // Do not specify tape copies here
   ) {
     const extra = archive ? {} : destinationPath;
+
     const jobParams = {
       username: user.username,
+      userToken: scicatToken,
       ...extra,
     };
 
@@ -57,9 +62,9 @@ export class ArchivingService {
     archive: boolean,
     destPath?: Record<string, string>,
   ): Observable<void> {
-    return combineLatest([this.currentUser$, this.tapeCopies$]).pipe(
+    return combineLatest([this.currentUser$, this.scicatToken$, this.tapeCopies$]).pipe(
       first(),
-      map(([user, tapeCopies]) => {
+      map(([user, token, tapeCopies]) => {
         if (user) {
           const email = user.email;
           if (email == null || email.length === 0) {
@@ -72,7 +77,7 @@ export class ArchivingService {
             throw new Error("No datasets selected");
           }
 
-          const job = this.createJob(user, datasets, archive, destPath);
+          const job = this.createJob(user, token, datasets, archive, destPath);
 
           this.store.dispatch(submitJobAction({ job: job as any }));
         }


### PR DESCRIPTION
## Description
Adds the scicat user token of the current user to the `jobParams` when creating a job in the backend.

This can be used for example in UrlAction to add an Authorization header:

```
    {
      "jobType": "archive",
      "create": {
        "auth": "#all",
        "actions": [
          {
            "actionType": "log"
          },
          {
            "actionType": "url",
            "url": "https://scopem-openem.ethz.ch/archiver/api/v1/archiver/jobs",
            "method": "POST",
            "headers": {
              "accept": "application/json",
              "content-type": "application/json",
              "Authorization": "Bearer {{jobParams.userToken}}"
            },
            "body": "{\"Type\": \"{{type}}\",\"Id\": \"{{id}}\"}"
          }
        ]
      },
      "update": {
        "auth": "#all"
      }
    },
```
